### PR TITLE
Feature/PN-15598 clients from multiple accounts (poc)

### DIFF
--- a/codegen/pn-infra-configurations.yaml
+++ b/codegen/pn-infra-configurations.yaml
@@ -34,7 +34,7 @@ envs:
           pn_macro_service_name: "pn-confinfo-bb"
           pn_ss_bucket_name: "pn-safestorage-eu-south-1-891377202032"
           clients_accounts_ids: "505630707203,755649575658"
-          clients_target_users_lists: "dev-interop-client-doc|dev-interop-client-jwt,qa-interop-client-doc|qa-interop-client-jwt"
+          clients_target_users_lists: "interop-dev-client-doc|interop-dev-client-jwt,interop-qa-client-doc|interop-qa-client-jwt"
 
   interop_prod:
     vpcs:

--- a/codegen/pn-infra-configurations.yaml
+++ b/codegen/pn-infra-configurations.yaml
@@ -33,8 +33,8 @@ envs:
           pn_backup_start_window: "60"
           pn_macro_service_name: "pn-confinfo-bb"
           pn_ss_bucket_name: "pn-safestorage-eu-south-1-891377202032"
-          clients_accounts_ids: "505630707203,755649575658,895646477129"
-          clients_target_users_lists: "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer|interop-dev-signed-object-persister,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer|interop-qa-signed-object-persister,interop-uat-document-signer|interop-uat-event-signer|interop-uat-audit-signer|interop-uat-signed-object-persister"
+          clients_accounts_ids: "505630707203,755649575658,895646477129,565393043798"
+          clients_target_users_lists: "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer|interop-dev-signed-object-persister,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer|interop-qa-signed-object-persister,interop-test-document-signer|interop-test-event-signer|interop-test-audit-signer|interop-test-signed-object-persister,interop-vapt-document-signer|interop-vapt-event-signer|interop-vapt-audit-signer|interop-vapt-signed-object-persister"
 
   interop_prod:
     vpcs:

--- a/codegen/pn-infra-configurations.yaml
+++ b/codegen/pn-infra-configurations.yaml
@@ -34,7 +34,7 @@ envs:
           pn_macro_service_name: "pn-confinfo-bb"
           pn_ss_bucket_name: "pn-safestorage-eu-south-1-891377202032"
           clients_accounts_ids: "505630707203,755649575658,895646477129"
-          clients_target_users_lists: "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer,interop-uat-document-signer|interop-uat-event-signer|interop-uat-audit-signer"
+          clients_target_users_lists: "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer|interop-dev-signed-object-persister,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer|interop-qa-signed-object-persister,interop-uat-document-signer|interop-uat-event-signer|interop-uat-audit-signer|interop-uat-signed-object-persister"
 
   interop_prod:
     vpcs:

--- a/codegen/pn-infra-configurations.yaml
+++ b/codegen/pn-infra-configurations.yaml
@@ -33,7 +33,8 @@ envs:
           pn_backup_start_window: "60"
           pn_macro_service_name: "pn-confinfo-bb"
           pn_ss_bucket_name: "pn-safestorage-eu-south-1-891377202032"
-
+          clients_accounts_ids: "505630707203,755649575658"
+          clients_target_users_lists: "dev-interop-client-doc|dev-interop-client-jwt,qa-interop-client-doc|qa-interop-client-jwt"
 
   interop_prod:
     vpcs:

--- a/codegen/pn-infra-configurations.yaml
+++ b/codegen/pn-infra-configurations.yaml
@@ -33,8 +33,8 @@ envs:
           pn_backup_start_window: "60"
           pn_macro_service_name: "pn-confinfo-bb"
           pn_ss_bucket_name: "pn-safestorage-eu-south-1-891377202032"
-          clients_accounts_ids: "505630707203,755649575658"
-          clients_target_users_lists: "interop-dev-client-doc|interop-dev-client-jwt,interop-qa-client-doc|interop-qa-client-jwt"
+          clients_accounts_ids: "505630707203,755649575658,895646477129"
+          clients_target_users_lists: "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer,interop-uat-document-signer|interop-uat-event-signer|interop-uat-audit-signer"
 
   interop_prod:
     vpcs:

--- a/src/main/60-load-balancers.tf
+++ b/src/main/60-load-balancers.tf
@@ -83,7 +83,14 @@ resource "aws_lb" "pn_confinfo_ecssin_nlb" {
 resource "aws_vpc_endpoint_service" "pn_confinfo_ecssin_endpoint_svc" {
   acceptance_required        = false
   network_load_balancer_arns = [aws_lb.pn_confinfo_ecssin_nlb.arn]
-  allowed_principals         = ["arn:aws:iam::${var.core_aws_account_id}:root"]
+  allowed_principals         = flatten([
+    "arn:aws:iam::${var.core_aws_account_id}:root",
+    [ 
+      for client_account_id in split(",", var.clients_accounts_ids): 
+        "arn:aws:iam::${trimspace(client_account_id)}:root" 
+          if length(trimspace(client_account_id)) > 0 && trimspace(client_account_id) != var.core_aws_account_id
+    ]
+  ])
 
   tags = {
     "Name": "PN ConfInfo - SafeStorage and ExternalChannel - SVC endpoint"

--- a/src/main/68-event-bus-external-destinations.tf
+++ b/src/main/68-event-bus-external-destinations.tf
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_event_target" "event_external_destination_target" {
   event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
   role_arn = aws_iam_role.send_safestorage_events_to_client_accounts.arn
   
-  target_id = format("SSN_client_user_%s", each.key)
+  target_id = format("user_%s", each.key)
   arn       = aws_sns_topic.client_ssn[ each.key ].arn
 
   dead_letter_config {

--- a/src/main/68-event-bus-external-destinations.tf
+++ b/src/main/68-event-bus-external-destinations.tf
@@ -1,0 +1,154 @@
+locals {
+  clients_accounts_ids = [ 
+    for id in split(",", var.clients_accounts_ids): 
+      trimspace(id) if length(trimspace(id)) > 0 
+  ]
+
+  clients_target_users_lists = [ 
+    for users_lists in split(",", var.clients_target_users_lists): 
+      trimspace(users_lists) if length(trimspace(users_lists)) > 0 
+  ]
+
+  split_clients_target_users_lists = flatten([
+    for idx, users_list in local.clients_target_users_lists: [
+        for user in split("|", users_list):
+          {
+            user_name = trimspace( user )
+            account_id = local.clients_accounts_ids[idx]
+          }
+            if length( trimspace( user )) > 0
+      ]
+  ])
+
+  clients_info = {
+    for user in local.split_clients_target_users_lists:
+      "${user.account_id}__${user.user_name}" => {
+        account_id = user.account_id
+        user_name = user.user_name
+        key = "${user.account_id}__${user.user_name}"
+      }
+  }
+
+}
+
+
+
+resource "aws_cloudwatch_event_rule" "event_client_accounts_destinations" {
+
+  for_each = local.clients_info
+
+  name = format("client_%s", each.key)
+  description = format("Send SafeStorage events to aws clients accounts %s", each.key)
+  event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
+  
+  role_arn = aws_iam_role.send_safestorage_events_to_client_accounts.arn
+
+  event_pattern = jsonencode({
+    source = [ "GESTORE DISPONIBILITA" ]
+    detail = {
+      client_short_code = [ each.value.user_name ]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "event_external_destination_target" {
+  for_each = local.clients_info
+  
+  rule      = aws_cloudwatch_event_rule.event_client_accounts_destinations[ each.key ].name
+  event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
+  role_arn = aws_iam_role.send_safestorage_events_to_client_accounts.arn
+  
+  target_id = format("SSN_client_user_%s", each.key)
+  arn       = aws_sns_topic.client_ssn[ each.key ].arn
+
+  dead_letter_config {
+    arn = aws_sqs_queue.EventBusDeadLetterQueue.arn
+  }
+
+}
+
+resource "aws_sns_topic" "client_ssn" {
+  for_each = local.clients_info
+
+  name = format("safestorage_client_%s", each.value.user_name)
+}
+
+resource "aws_sns_topic_policy" "client_ssn_policy" {
+  for_each = local.clients_info
+
+  arn = aws_sns_topic.client_ssn[ each.key ].arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sns:Subscribe"
+        ]
+        Principal = {
+            AWS = each.value.account_id
+        }
+        Resource = [
+          aws_sns_topic.client_ssn[ each.key ].arn
+        ]   
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "send_safestorage_events_to_client_accounts" {
+  name_prefix = "send_evt_role"
+
+  assume_role_policy = data.aws_iam_policy_document.event_bridge_can_assume.json
+
+}
+
+data "aws_iam_policy_document" "event_bridge_can_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    /*condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [
+        aws_cloudwatch_event_bus.PnConfinfoEventBus.arn
+      ]
+    }*/
+  }
+}
+
+resource "aws_iam_role_policy" "event_bus_to_topic" {
+  name = "SendToSNS4Clients"
+  role = aws_iam_role.send_safestorage_events_to_client_accounts.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sns:GetTopicAttributes",
+          "sns:Publish",
+          "sns:PublishBatch"
+        ]
+        Resource = [
+          for info in values(local.clients_info):
+            aws_sns_topic.client_ssn[ info.key ].arn
+        ]
+      }
+    ]
+  })
+}

--- a/src/main/68-event-bus-external-destinations.tf
+++ b/src/main/68-event-bus-external-destinations.tf
@@ -31,9 +31,11 @@ locals {
 
 }
 
+# TODO aggiungere DLQ ai topic
 
 
-resource "aws_cloudwatch_event_rule" "event_client_accounts_destinations" {
+
+resource "aws_cloudwatch_event_rule" "event_to_clients_sns_topics_rules" {
 
   for_each = local.clients_info
 
@@ -41,7 +43,7 @@ resource "aws_cloudwatch_event_rule" "event_client_accounts_destinations" {
   description = format("Send SafeStorage events to aws clients accounts %s", each.key)
   event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
   
-  role_arn = aws_iam_role.send_safestorage_events_to_client_accounts.arn
+  role_arn = aws_iam_role.send_safestorage_events_to_clients_topics_role.arn
 
   event_pattern = jsonencode({
     source = [ "GESTORE DISPONIBILITA" ]
@@ -51,12 +53,12 @@ resource "aws_cloudwatch_event_rule" "event_client_accounts_destinations" {
   })
 }
 
-resource "aws_cloudwatch_event_target" "event_external_destination_target" {
+resource "aws_cloudwatch_event_target" "event_to_clients_sns_topics_targets" {
   for_each = local.clients_info
   
-  rule      = aws_cloudwatch_event_rule.event_client_accounts_destinations[ each.key ].name
+  rule      = aws_cloudwatch_event_rule.event_to_clients_sns_topics_rules[ each.key ].name
   event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
-  role_arn = aws_iam_role.send_safestorage_events_to_client_accounts.arn
+  role_arn = aws_iam_role.send_safestorage_events_to_clients_topics_role.arn
   
   target_id = format("user_%s", each.key)
   arn       = aws_sns_topic.client_ssn[ each.key ].arn
@@ -97,7 +99,7 @@ resource "aws_sns_topic_policy" "client_ssn_policy" {
   })
 }
 
-resource "aws_iam_role" "send_safestorage_events_to_client_accounts" {
+resource "aws_iam_role" "send_safestorage_events_to_clients_topics_role" {
   name_prefix = "send_evt_role"
 
   assume_role_policy = data.aws_iam_policy_document.event_bridge_can_assume.json
@@ -119,20 +121,12 @@ data "aws_iam_policy_document" "event_bridge_can_assume" {
       variable = "aws:SourceAccount"
       values   = [data.aws_caller_identity.current.account_id]
     }
-
-    /*condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-      values   = [
-        aws_cloudwatch_event_bus.PnConfinfoEventBus.arn
-      ]
-    }*/
   }
 }
 
-resource "aws_iam_role_policy" "event_bus_to_topic" {
+resource "aws_iam_role_policy" "event_bus_to_topics" {
   name = "SendToSNS4Clients"
-  role = aws_iam_role.send_safestorage_events_to_client_accounts.id
+  role = aws_iam_role.send_safestorage_events_to_clients_topics_role.id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/src/main/68-event-bus-external-destinations.tf
+++ b/src/main/68-event-bus-external-destinations.tf
@@ -1,14 +1,27 @@
 locals {
+  # - Because of a limitation on the CI/CD scripts we can handle only string vars.
+  # - This set of locals mangle the vars to obtain a normalized data structure 
+  #   memorized in  
+
+  # - Split client's AWS account id list
   clients_accounts_ids = [ 
     for id in split(",", var.clients_accounts_ids): 
       trimspace(id) if length(trimspace(id)) > 0 
   ]
 
+  # - The SafeStorage clients list is separated by '|' (pipe)  and ',' (comma).
+  #   Comma is used to separate different AWS accounts, 
+  #   pipe is used to separate clients names in the same AWS account.
+  # - This locals contains the list split on commas, the next contains the "full split"
   clients_target_users_lists = [ 
     for users_lists in split(",", var.clients_target_users_lists): 
       trimspace(users_lists) if length(trimspace(users_lists)) > 0 
   ]
 
+  # - This local contains an array of array.
+  #   The outer array contains one element for each AWS Account;
+  #   every element is an inner array containing the list of safe-storage clients that 
+  #   run on one AWS Account
   split_clients_target_users_lists = flatten([
     for idx, users_list in local.clients_target_users_lists: [
         for user in split("|", users_list):
@@ -20,6 +33,9 @@ locals {
       ]
   ])
 
+  # - Normalized data structure. clients_info is a "map" that associate a
+  #   key of type string composed joining the AWS account id and the safestorage-client-short-code
+  #   with a value composed by the same two values as distinct properties.
   clients_info = {
     for user in local.split_clients_target_users_lists:
       "${user.account_id}__${user.user_name}" => {
@@ -31,50 +47,15 @@ locals {
 
 }
 
-# TODO aggiungere DLQ ai topic
-
-
-
-resource "aws_cloudwatch_event_rule" "event_to_clients_sns_topics_rules" {
-
-  for_each = local.clients_info
-
-  name = format("client_%s", each.key)
-  description = format("Send SafeStorage events to aws clients accounts %s", each.key)
-  event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
-  
-  role_arn = aws_iam_role.send_safestorage_events_to_clients_topics_role.arn
-
-  event_pattern = jsonencode({
-    source = [ "GESTORE DISPONIBILITA" ]
-    detail = {
-      client_short_code = [ each.value.user_name ]
-    }
-  })
-}
-
-resource "aws_cloudwatch_event_target" "event_to_clients_sns_topics_targets" {
-  for_each = local.clients_info
-  
-  rule      = aws_cloudwatch_event_rule.event_to_clients_sns_topics_rules[ each.key ].name
-  event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
-  role_arn = aws_iam_role.send_safestorage_events_to_clients_topics_role.arn
-  
-  target_id = format("user_%s", each.key)
-  arn       = aws_sns_topic.client_ssn[ each.key ].arn
-
-  dead_letter_config {
-    arn = aws_sqs_queue.EventBusDeadLetterQueue.arn
-  }
-
-}
-
+# - One SNS topic for each safe-storage client
 resource "aws_sns_topic" "client_ssn" {
   for_each = local.clients_info
 
   name = format("safe_storage_client_%s", each.value.user_name)
 }
 
+# One distinct policy for every SNS topic; this policy allow subscription 
+# to the topic from the AWS Account associated to the safe-storage client.
 resource "aws_sns_topic_policy" "client_ssn_policy" {
   for_each = local.clients_info
 
@@ -99,13 +80,52 @@ resource "aws_sns_topic_policy" "client_ssn_policy" {
   })
 }
 
+
+# - One EventBus rule for each safe-storage client
+resource "aws_cloudwatch_event_rule" "event_to_clients_sns_topics_rules" {
+
+  for_each = local.clients_info
+
+  name = format("client_%s", each.key)
+  description = format("Send SafeStorage events to aws clients accounts %s", each.key)
+  event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
+  
+  role_arn = aws_iam_role.send_safestorage_events_to_clients_topics_role.arn
+
+  event_pattern = jsonencode({
+    source = [ "GESTORE DISPONIBILITA" ]
+    detail = {
+      client_short_code = [ each.value.user_name ]
+    }
+  })
+}
+
+# - One target for every rule (one for each safe-storage client)
+resource "aws_cloudwatch_event_target" "event_to_clients_sns_topics_targets" {
+  for_each = local.clients_info
+  
+  rule      = aws_cloudwatch_event_rule.event_to_clients_sns_topics_rules[ each.key ].name
+  event_bus_name = aws_cloudwatch_event_bus.PnConfinfoEventBus.name
+  role_arn = aws_iam_role.send_safestorage_events_to_clients_topics_role.arn
+  
+  target_id = format("user_%s", each.key)
+  arn       = aws_sns_topic.client_ssn[ each.key ].arn
+
+  dead_letter_config {
+    arn = aws_sqs_queue.EventBusDeadLetterQueue.arn
+  }
+}
+
+
+# - Only one role for EventBridge, used by all the rules and targets.
+#   It simply allow EventBridge to write to all the SNS topic created by this terraform file.
 resource "aws_iam_role" "send_safestorage_events_to_clients_topics_role" {
   name_prefix = "send_evt_role"
 
   assume_role_policy = data.aws_iam_policy_document.event_bridge_can_assume.json
-
 }
 
+# - Avoid https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html#cross-service-confused-deputy-prevention
 data "aws_iam_policy_document" "event_bridge_can_assume" {
   statement {
     effect  = "Allow"

--- a/src/main/68-event-bus-external-destinations.tf
+++ b/src/main/68-event-bus-external-destinations.tf
@@ -70,7 +70,7 @@ resource "aws_cloudwatch_event_target" "event_external_destination_target" {
 resource "aws_sns_topic" "client_ssn" {
   for_each = local.clients_info
 
-  name = format("safestorage_client_%s", each.value.user_name)
+  name = format("safe_storage_client_%s", each.value.user_name)
 }
 
 resource "aws_sns_topic_policy" "client_ssn_policy" {

--- a/src/main/68-event-bus-external-destinations.tf
+++ b/src/main/68-event-bus-external-destinations.tf
@@ -20,7 +20,7 @@ locals {
 
   # - This local contains an array of array.
   #   The outer array contains one element for each AWS Account;
-  #   every element is an inner array containing the list of safe-storage clients that 
+  #   every element is an inner array containing the list of safestorage clients that 
   #   run on one AWS Account
   split_clients_target_users_lists = flatten([
     for idx, users_list in local.clients_target_users_lists: [
@@ -34,7 +34,7 @@ locals {
   ])
 
   # - Normalized data structure. clients_info is a "map" that associate a
-  #   key of type string composed joining the AWS account id and the safestorage-client-short-code
+  #   key of type string composed joining the AWS account id and the safestorage client-short-code
   #   with a value composed by the same two values as distinct properties.
   clients_info = {
     for user in local.split_clients_target_users_lists:
@@ -47,7 +47,7 @@ locals {
 
 }
 
-# - One SNS topic for each safe-storage client
+# - One SNS topic for each safestorage client
 resource "aws_sns_topic" "client_ssn" {
   for_each = local.clients_info
 
@@ -55,7 +55,7 @@ resource "aws_sns_topic" "client_ssn" {
 }
 
 # One distinct policy for every SNS topic; this policy allow subscription 
-# to the topic from the AWS Account associated to the safe-storage client.
+# to the topic from the AWS Account associated to the safestorage client.
 resource "aws_sns_topic_policy" "client_ssn_policy" {
   for_each = local.clients_info
 
@@ -81,7 +81,7 @@ resource "aws_sns_topic_policy" "client_ssn_policy" {
 }
 
 
-# - One EventBus rule for each safe-storage client
+# - One EventBus rule for each safestorage client
 resource "aws_cloudwatch_event_rule" "event_to_clients_sns_topics_rules" {
 
   for_each = local.clients_info
@@ -100,7 +100,7 @@ resource "aws_cloudwatch_event_rule" "event_to_clients_sns_topics_rules" {
   })
 }
 
-# - One target for every rule (one for each safe-storage client)
+# - One target for every rule (one for each safestorage client)
 resource "aws_cloudwatch_event_target" "event_to_clients_sns_topics_targets" {
   for_each = local.clients_info
   

--- a/src/main/68-event-bus.tf
+++ b/src/main/68-event-bus.tf
@@ -11,6 +11,11 @@ resource "aws_sqs_queue" "EventBusDeadLetterQueue" {
   receive_wait_time_seconds = 10
 }
 
+resource "aws_cloudwatch_event_bus" "DevNullEventBus" {
+  name = "${var.ProjectName}-DevNullEventBus"
+}
+
+
 data "aws_iam_policy_document" "PnConfinfoEventBusAccessPolicy" {
   statement {
     sid    = "AccountAccess"

--- a/src/main/98-variables.tf
+++ b/src/main/98-variables.tf
@@ -107,6 +107,26 @@ variable "pn_core_event_bus_arn" {
   description = "core account event bus arn"
 }
 
+variable "clients_accounts_ids" {
+  type        = string
+  default     = ""
+  description = "Comma separated list of AWS accounts allowed to invoke exposed Service Endpoint"
+}
+
+variable "clients_target_users_lists" {
+  type        = string
+  default     = ""
+  description = <<EOF
+    A comma separated list of list separated by | symbol. 
+    Every element is a SafeStorage user name. 
+    
+    Example: dev-interop_001|dev-interop_002,qa-interop_001|qa-interop_002
+    This means that two client aws accounts are used and
+     - First aws account use dev-interop_001 and dev-interop_002 SafeStorage users.
+     - Second aws account use qa-interop_001 and qa-interop_002 SafeStorage users.
+EOF 
+}
+
 variable "ProjectName" {
   type        = string
   default     = "pn"

--- a/src/main/99-outputs.tf
+++ b/src/main/99-outputs.tf
@@ -98,7 +98,7 @@ output "ConfInfo_CoreAwsAccountId" {
 }
 
 output "ConfInfo_PnCoreTargetEventBus" {
-  value = var.pn_core_event_bus_arn
+  value = length(local.clients_accounts_ids) > 0 ? aws_cloudwatch_event_bus.DevNullEventBus.arn : var.pn_core_event_bus_arn
   description = "core event bridge bus"
 }
 

--- a/src/main/env/interop_uat/terraform.tfvars
+++ b/src/main/env/interop_uat/terraform.tfvars
@@ -30,7 +30,7 @@ pn_backup_start_window = "60"
 pn_macro_service_name = "pn-confinfo-bb"
 pn_ss_bucket_name = "pn-safestorage-eu-south-1-891377202032"
 clients_accounts_ids = "505630707203,755649575658"
-clients_target_users_lists = "dev-interop-client-doc|dev-interop-client-jwt,qa-interop-client-doc|qa-interop-client-jwt"
+clients_target_users_lists = "interop-dev-client-doc|interop-dev-client-jwt,interop-qa-client-doc|interop-qa-client-jwt"
 
 
 vpc_pn_confinfo_name = "PN ConfInfo BB"

--- a/src/main/env/interop_uat/terraform.tfvars
+++ b/src/main/env/interop_uat/terraform.tfvars
@@ -29,8 +29,8 @@ pn_backup_cron_expression = "cron(0 4 * * ? *)"
 pn_backup_start_window = "60"
 pn_macro_service_name = "pn-confinfo-bb"
 pn_ss_bucket_name = "pn-safestorage-eu-south-1-891377202032"
-clients_accounts_ids = "505630707203,755649575658"
-clients_target_users_lists = "interop-dev-client-doc|interop-dev-client-jwt,interop-qa-client-doc|interop-qa-client-jwt"
+clients_accounts_ids = "505630707203,755649575658,895646477129"
+clients_target_users_lists = "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer,interop-uat-document-signer|interop-uat-event-signer|interop-uat-audit-signer"
 
 
 vpc_pn_confinfo_name = "PN ConfInfo BB"

--- a/src/main/env/interop_uat/terraform.tfvars
+++ b/src/main/env/interop_uat/terraform.tfvars
@@ -30,7 +30,7 @@ pn_backup_start_window = "60"
 pn_macro_service_name = "pn-confinfo-bb"
 pn_ss_bucket_name = "pn-safestorage-eu-south-1-891377202032"
 clients_accounts_ids = "505630707203,755649575658,895646477129"
-clients_target_users_lists = "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer,interop-uat-document-signer|interop-uat-event-signer|interop-uat-audit-signer"
+clients_target_users_lists = "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer|interop-dev-signed-object-persister,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer|interop-qa-signed-object-persister,interop-uat-document-signer|interop-uat-event-signer|interop-uat-audit-signer|interop-uat-signed-object-persister"
 
 
 vpc_pn_confinfo_name = "PN ConfInfo BB"

--- a/src/main/env/interop_uat/terraform.tfvars
+++ b/src/main/env/interop_uat/terraform.tfvars
@@ -29,6 +29,8 @@ pn_backup_cron_expression = "cron(0 4 * * ? *)"
 pn_backup_start_window = "60"
 pn_macro_service_name = "pn-confinfo-bb"
 pn_ss_bucket_name = "pn-safestorage-eu-south-1-891377202032"
+clients_accounts_ids = "505630707203,755649575658"
+clients_target_users_lists = "dev-interop-client-doc|dev-interop-client-jwt,qa-interop-client-doc|qa-interop-client-jwt"
 
 
 vpc_pn_confinfo_name = "PN ConfInfo BB"

--- a/src/main/env/interop_uat/terraform.tfvars
+++ b/src/main/env/interop_uat/terraform.tfvars
@@ -29,8 +29,8 @@ pn_backup_cron_expression = "cron(0 4 * * ? *)"
 pn_backup_start_window = "60"
 pn_macro_service_name = "pn-confinfo-bb"
 pn_ss_bucket_name = "pn-safestorage-eu-south-1-891377202032"
-clients_accounts_ids = "505630707203,755649575658,895646477129"
-clients_target_users_lists = "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer|interop-dev-signed-object-persister,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer|interop-qa-signed-object-persister,interop-uat-document-signer|interop-uat-event-signer|interop-uat-audit-signer|interop-uat-signed-object-persister"
+clients_accounts_ids = "505630707203,755649575658,895646477129,565393043798"
+clients_target_users_lists = "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer|interop-dev-signed-object-persister,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer|interop-qa-signed-object-persister,interop-test-document-signer|interop-test-event-signer|interop-test-audit-signer|interop-test-signed-object-persister,interop-vapt-document-signer|interop-vapt-event-signer|interop-vapt-audit-signer|interop-vapt-signed-object-persister"
 
 
 vpc_pn_confinfo_name = "PN ConfInfo BB"


### PR DESCRIPTION
Questa PR vuole essere una proposta implementativa della feature richiesta.

Implementa una comunicazione mediata tramite SNS creando un topic SNS per ogni client e dandogli la possibilità di creare "subscription". 
Il compito di creare coda SQS, o altro tipo di endpoint supportato da SNS, ed effettuare la subscription è lasciato al client. anche per ragioni di flessibilità.

__N.B.__: questa PR lascia scoperta la problematica di allineamento automatico tra gli utenti censiti a livello di infrastruttura e gli utenti censiti nella tabella.

__N.B.__: Si p scelto di inviare gli eventi "cross-account" tramite SNS+SQS per avitare problemi con la limitazione "EventBridge can't route events received from a sender event bus to a third event bus" documentata in https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-bus-to-bus.html