### PR TITLE
fix(safestorage-bb) rename interop clients (PN-16736)

### DIFF
--- a/codegen/pn-infra-configurations.yaml
+++ b/codegen/pn-infra-configurations.yaml
@@ -34,7 +34,7 @@ envs:
           pn_macro_service_name: "pn-confinfo-bb"
           pn_ss_bucket_name: "pn-safestorage-eu-south-1-891377202032"
           clients_accounts_ids: "505630707203,755649575658,895646477129,565393043798,533267098416"
-          clients_target_users_lists: "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer|interop-dev-signed-object-persister,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer|interop-qa-signed-object-persister,interop-test-document-signer|interop-test-event-signer|interop-test-audit-signer|interop-test-signed-object-persister,interop-vapt-document-signer|interop-vapt-event-signer|interop-vapt-audit-signer|interop-vapt-signed-object-persister,interop-att-document-signer|interop-att-event-signer|interop-att-audit-signer|interop-att-signed-object-persister"
+          clients_target_users_lists: "interop-dev-documents-signer|interop-dev-events-signer|interop-dev-audit-signer|interop-dev-signed-objects-persister,interop-qa-documents-signer|interop-qa-events-signer|interop-qa-audit-signer|interop-qa-signed-objects-persister,interop-test-documents-signer|interop-test-events-signer|interop-test-audit-signer|interop-test-signed-objects-persister,interop-vapt-documents-signer|interop-vapt-events-signer|interop-vapt-audit-signer|interop-vapt-signed-objects-persister,interop-att-documents-signer|interop-att-events-signer|interop-att-audit-signer|interop-att-signed-objects-persister"
 
   interop_prod:
     vpcs:
@@ -70,7 +70,7 @@ envs:
           pn_macro_service_name: "pn-confinfo-bb"
           pn_ss_bucket_name: "pn-safestorage-eu-south-1-730335668132"
           clients_accounts_ids: "697818730278"
-          clients_target_users_lists: "interop-prod-document-signer|interop-prod-event-signer|interop-prod-audit-signer|interop-prod-signed-object-persister"
+          clients_target_users_lists: "interop-prod-documents-signer|interop-prod-events-signer|interop-prod-audit-signer|interop-prod-signed-objects-persister"
 
 accounts:
   - code: pn-confinfo

--- a/codegen/pn-infra-configurations.yaml
+++ b/codegen/pn-infra-configurations.yaml
@@ -69,6 +69,8 @@ envs:
           pn_backup_start_window: "60"
           pn_macro_service_name: "pn-confinfo-bb"
           pn_ss_bucket_name: "pn-safestorage-eu-south-1-730335668132"
+          clients_accounts_ids: "697818730278"
+          clients_target_users_lists: "interop-prod-document-signer|interop-prod-event-signer|interop-prod-audit-signer|interop-prod-signed-object-persister"
 
 accounts:
   - code: pn-confinfo

--- a/src/main/env/interop_prod/terraform.tfvars
+++ b/src/main/env/interop_prod/terraform.tfvars
@@ -29,6 +29,8 @@ pn_backup_cron_expression = "cron(0 4 * * ? *)"
 pn_backup_start_window = "60"
 pn_macro_service_name = "pn-confinfo-bb"
 pn_ss_bucket_name = "pn-safestorage-eu-south-1-730335668132"
+clients_accounts_ids = "697818730278"
+clients_target_users_lists = "interop-prod-document-signer|interop-prod-event-signer|interop-prod-audit-signer|interop-prod-signed-object-persister"
 
 
 vpc_pn_confinfo_name = "PN ConfInfo BB"

--- a/src/main/env/interop_prod/terraform.tfvars
+++ b/src/main/env/interop_prod/terraform.tfvars
@@ -30,7 +30,7 @@ pn_backup_start_window = "60"
 pn_macro_service_name = "pn-confinfo-bb"
 pn_ss_bucket_name = "pn-safestorage-eu-south-1-730335668132"
 clients_accounts_ids = "697818730278"
-clients_target_users_lists = "interop-prod-document-signer|interop-prod-event-signer|interop-prod-audit-signer|interop-prod-signed-object-persister"
+clients_target_users_lists = "interop-prod-documents-signer|interop-prod-events-signer|interop-prod-audit-signer|interop-prod-signed-objects-persister"
 
 
 vpc_pn_confinfo_name = "PN ConfInfo BB"

--- a/src/main/env/interop_uat/terraform.tfvars
+++ b/src/main/env/interop_uat/terraform.tfvars
@@ -30,7 +30,7 @@ pn_backup_start_window = "60"
 pn_macro_service_name = "pn-confinfo-bb"
 pn_ss_bucket_name = "pn-safestorage-eu-south-1-891377202032"
 clients_accounts_ids = "505630707203,755649575658,895646477129,565393043798,533267098416"
-clients_target_users_lists = "interop-dev-document-signer|interop-dev-event-signer|interop-dev-audit-signer|interop-dev-signed-object-persister,interop-qa-document-signer|interop-qa-event-signer|interop-qa-audit-signer|interop-qa-signed-object-persister,interop-test-document-signer|interop-test-event-signer|interop-test-audit-signer|interop-test-signed-object-persister,interop-vapt-document-signer|interop-vapt-event-signer|interop-vapt-audit-signer|interop-vapt-signed-object-persister,interop-att-document-signer|interop-att-event-signer|interop-att-audit-signer|interop-att-signed-object-persister"
+clients_target_users_lists = "interop-dev-documents-signer|interop-dev-events-signer|interop-dev-audit-signer|interop-dev-signed-objects-persister,interop-qa-documents-signer|interop-qa-events-signer|interop-qa-audit-signer|interop-qa-signed-objects-persister,interop-test-documents-signer|interop-test-events-signer|interop-test-audit-signer|interop-test-signed-objects-persister,interop-vapt-documents-signer|interop-vapt-events-signer|interop-vapt-audit-signer|interop-vapt-signed-objects-persister,interop-att-documents-signer|interop-att-events-signer|interop-att-audit-signer|interop-att-signed-objects-persister"
 
 
 vpc_pn_confinfo_name = "PN ConfInfo BB"


### PR DESCRIPTION
Following SafeStorage-BB clients have to be renamed:
 - `interop-<envName>-document-signer` --> `interop-<envName>-documents-signer`
 - `interop-<envName>-event-signer` --> `interop-<envName>-events-signer`
 - `interop-<envName>-signed-object-persister` --> `interop-<envName>-signed-objects-persister`

where `<envName>` can assume values: `dev`, `qa`, `test`, `vapt`, `att`